### PR TITLE
Varlink refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.swp
 
 passes.yml
 vault.yml

--- a/example-varlink.yml
+++ b/example-varlink.yml
@@ -1,6 +1,7 @@
 ---
 
 - hosts: all
+  become: true
 
   vars:
     com_redhat_ntp:

--- a/example-varlink.yml
+++ b/example-varlink.yml
@@ -19,9 +19,6 @@
           iburst: false
 
   roles:
-    - role: varlink
-      interfaces:
-        - 'com.redhat.ntp'
-
+    - varlink
     - com_redhat_ntp
 

--- a/roles/com_redhat_ntp/handlers/main.yaml
+++ b/roles/com_redhat_ntp/handlers/main.yaml
@@ -1,5 +1,4 @@
 ---
 
 - name: restart chrony
-  become: true
   service: name=chronyd state=restarted

--- a/roles/com_redhat_ntp/tasks/main.yaml
+++ b/roles/com_redhat_ntp/tasks/main.yaml
@@ -1,5 +1,9 @@
 ---
 
+- name: Gather config
+  action: varlink interface=com.redhat.ntp
+  register: config
+
 - name: Install chrony
   package: name=chrony state=present
 

--- a/roles/com_redhat_ntp/tasks/main.yaml
+++ b/roles/com_redhat_ntp/tasks/main.yaml
@@ -1,10 +1,8 @@
 ---
 
 - name: Install chrony
-  become: true
   package: name=chrony state=present
 
 - name: Generate chrony.conf
-  become: true
   template: src=chrony.conf.j2 dest=/etc/chrony.conf
   notify: restart chrony

--- a/roles/com_redhat_ntp/templates/chrony.conf.j2
+++ b/roles/com_redhat_ntp/templates/chrony.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-{% for server in com_redhat_ntp.ntp_servers %}
+{% for server in config.ntp_servers %}
 {% if server.pool %}pool {% else %}server {% endif -%}
 {{server.hostname}} minpoll {{server.minpoll}} maxpoll {{server.maxpoll}}
 {%- if server.iburst %} iburst {% endif %}

--- a/roles/varlink/action_plugins/varlink.py
+++ b/roles/varlink/action_plugins/varlink.py
@@ -19,22 +19,22 @@ class ActionModule(ActionBase):
         facts = {}
 
         for name in task_vars.get('interfaces', []):
-            varlink_file = 'varlink/%s.api' % name
             varname = name.replace('.', '_')
 
+            varlink_file = 'varlink/%s.api' % name
             try:
                 description = file(varlink_file).read()
                 interface = varlink.Interface(description)
             except (ValueError, IOError) as error:
                 return dict(failed=True, msg='cannot read interface file `%s`: %s' % (varlink_file, error.strerror))
 
-            config = task_vars.get(varname)
-            if not config:
-                defaults_file = 'varlink/%s.defaults' % name
-                try:
-                    config = json.load(file(defaults_file))
-                except (ValueError, IOError) as error:
-                    return dict(failed=True, msg='cannot read defaults from `%s`: %s' % (defaults_file, str(error)))
+            defaults_file = 'varlink/%s.defaults' % name
+            try:
+                config = json.load(file(defaults_file))
+            except (ValueError, IOError) as error:
+                return dict(failed=True, msg='cannot read defaults from `%s`: %s' % (defaults_file, str(error)))
+
+            config.update(task_vars.get(varname, {}))
 
             try:
                 variant = varlink.Variant(interface, 'Config', config)

--- a/roles/varlink/tasks/main.yaml
+++ b/roles/varlink/tasks/main.yaml
@@ -1,4 +1,0 @@
----
-
-- name: Applying configuration
-  action: varlink


### PR DESCRIPTION
Turn the way we read variables inside out to alleviate the first problem I mentioned on the original pull request #3. Instead of going through all interfaces in the action plugin and setting host facts, call the plugin in each role and put them into a registered variable.

Also merge top-level config keys from the `.defaults` file. Eventually, we may want to have defaults in the `.api` files, so that we can have defaults for nested structs as well.