### PR TITLE
Varlink tuned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.swp
 
 passes.yml
 vault.yml

--- a/example-varlink.yml
+++ b/example-varlink.yml
@@ -18,7 +18,11 @@
           maxpoll: 500
           iburst: false
 
+    com_redhat_tuned:
+      profile: "throughput-performance"
+
   roles:
     - varlink
     - com_redhat_ntp
+    - com_redhat_tuned
 

--- a/example-varlink.yml
+++ b/example-varlink.yml
@@ -1,6 +1,7 @@
 ---
 
 - hosts: all
+  become: true
 
   vars:
     com_redhat_ntp:

--- a/example-varlink.yml
+++ b/example-varlink.yml
@@ -19,9 +19,6 @@
           iburst: false
 
   roles:
-    - role: varlink
-      interfaces:
-        - 'com.redhat.ntp'
-
+    - varlink
     - com_redhat_ntp
 

--- a/roles/com_redhat_ntp/handlers/main.yaml
+++ b/roles/com_redhat_ntp/handlers/main.yaml
@@ -1,5 +1,4 @@
 ---
 
 - name: restart chrony
-  become: true
   service: name=chronyd state=restarted

--- a/roles/com_redhat_ntp/tasks/main.yaml
+++ b/roles/com_redhat_ntp/tasks/main.yaml
@@ -1,5 +1,9 @@
 ---
 
+- name: Gather config
+  action: varlink interface=com.redhat.ntp
+  register: config
+
 - name: Install chrony
   package: name=chrony state=present
 

--- a/roles/com_redhat_ntp/tasks/main.yaml
+++ b/roles/com_redhat_ntp/tasks/main.yaml
@@ -1,10 +1,8 @@
 ---
 
 - name: Install chrony
-  become: true
   package: name=chrony state=present
 
 - name: Generate chrony.conf
-  become: true
   template: src=chrony.conf.j2 dest=/etc/chrony.conf
   notify: restart chrony

--- a/roles/com_redhat_ntp/templates/chrony.conf.j2
+++ b/roles/com_redhat_ntp/templates/chrony.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-{% for server in com_redhat_ntp.ntp_servers %}
+{% for server in config.ntp_servers %}
 {% if server.pool %}pool {% else %}server {% endif -%}
 {{server.hostname}} minpoll {{server.minpoll}} maxpoll {{server.maxpoll}}
 {%- if server.iburst %} iburst {% endif %}

--- a/roles/com_redhat_tuned/handlers/main.yml
+++ b/roles/com_redhat_tuned/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart tuned
+  service: name=tuned state=restarted

--- a/roles/com_redhat_tuned/tasks/main.yaml
+++ b/roles/com_redhat_tuned/tasks/main.yaml
@@ -1,0 +1,41 @@
+---
+- name: Gather config
+  action: varlink interface=com.redhat.tuned
+  register: config
+
+- name: Install Tuned
+  package: name=tuned state=latest
+
+- name: Enable Tuned
+  service: name=tuned state=started enabled=yes
+
+- name: Check for Tuned legacy
+  shell: tuned --version &> /dev/null || echo -n "legacy"
+  register: tversion
+
+- set_fact:
+    tuned_legacy: "{{ (tversion.stdout == 'legacy') | ternary(true,false) }}"
+
+- name: Generate tuned-main.conf file
+  template: src=tuned-main.conf.j2 dest=/etc/tuned/tuned-main.conf
+  notify: restart tuned
+  when: not tuned_legacy
+
+- name: Get Tuned recommended profile
+  shell: tuned-adm recommend 2> /dev/null || echo -n " *fail"
+  register: recommend
+
+- set_fact:
+    tuned_recommended_profile: "{{ (recommend.stdout == ' *fail') | ternary('',recommend.stdout) }}"
+
+- name: Set Tuned legacy profile {{ tuned_legacy_profile }}
+  command: tuned-adm profile {{ tuned_legacy_profile }}
+  when: tuned_legacy and tuned_legacy_profile != ""
+
+- name: Set Tuned profile {{ config.profile }}
+  command: tuned-adm profile {{ config.profile }}
+  when: not tuned_legacy and not config.use_recommended_profile and config.profile != ""
+
+- name: Set recommended Tuned profile {{ tuned_recommended_profile }}
+  command: tuned-adm profile {{ tuned_recommended_profile }}
+  when: not tuned_legacy and config.use_recommended_profile

--- a/roles/com_redhat_tuned/templates/tuned-main.conf.j2
+++ b/roles/com_redhat_tuned/templates/tuned-main.conf.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+
+daemon = {{ config.daemon }}
+dynamic_tuning = {{ config.dynamic_tuning }}
+sleep_interval = {{ config.sleep_interval }}
+update_interval = {{ config.update_interval }}
+recommend_command = {{ config.enable_recommend }}
+reapply_sysctl = {{ config.reapply_sysctl }}

--- a/roles/varlink/action_plugins/varlink.py
+++ b/roles/varlink/action_plugins/varlink.py
@@ -19,22 +19,22 @@ class ActionModule(ActionBase):
         facts = {}
 
         for name in task_vars.get('interfaces', []):
-            varlink_file = 'varlink/%s.api' % name
             varname = name.replace('.', '_')
 
+            varlink_file = 'varlink/%s.api' % name
             try:
                 description = file(varlink_file).read()
                 interface = varlink.Interface(description)
             except (ValueError, IOError) as error:
                 return dict(failed=True, msg='cannot read interface file `%s`: %s' % (varlink_file, error.strerror))
 
-            config = task_vars.get(varname)
-            if not config:
-                defaults_file = 'varlink/%s.defaults' % name
-                try:
-                    config = json.load(file(defaults_file))
-                except (ValueError, IOError) as error:
-                    return dict(failed=True, msg='cannot read defaults from `%s`: %s' % (defaults_file, str(error)))
+            defaults_file = 'varlink/%s.defaults' % name
+            try:
+                config = json.load(file(defaults_file))
+            except (ValueError, IOError) as error:
+                return dict(failed=True, msg='cannot read defaults from `%s`: %s' % (defaults_file, str(error)))
+
+            config.update(task_vars.get(varname, {}))
 
             try:
                 variant = varlink.Variant(interface, 'Config', config)

--- a/roles/varlink/tasks/main.yaml
+++ b/roles/varlink/tasks/main.yaml
@@ -1,4 +1,0 @@
----
-
-- name: Applying configuration
-  action: varlink

--- a/varlink/com.redhat.tuned.api
+++ b/varlink/com.redhat.tuned.api
@@ -1,0 +1,45 @@
+
+/**
+ * Tuned profile configuration
+ *
+ * use_recommended_profile:
+ *   Set the profile which is recommended for the machine instead of the one
+ *   given in 'profile'.
+ *
+ * profile:
+ *   The profile to set. Unused if use_recommended_profile is true. Basic
+ *   profiles that are available are "balanced", "powersave",
+ *   "throughput-performance", and "latency-performance". More profiles may be
+ *   available depending on OS version.
+ *
+ * daemon:
+ *   If true, enable the daemon to support dynamic tuning.
+ *
+ * dynamic_tuning:
+ *   Enable dynamic tuning.
+ *
+ * sleep_interval:
+ *   Sleep interval for checking for events, in seconds.
+ *
+ * update_interval:
+ *   Update interval for dynamic tuning, in seconds.
+ *
+ * enable_recommend:
+ *   Enable recommend functionality.
+ *
+ * reapply_sysctl:
+ *   Wether to apply sysctl from /etc after tuned's sysctl are applied.
+ */
+
+com.redhat.tuned {
+  type Config (
+    use_recommended_profile: bool,
+    profile: string,
+    daemon: bool,
+    dynamic_tuning: bool,
+    sleep_interval: uint64,
+    update_interval: uint64,
+    enable_recommend: bool,
+    reapply_sysctl: bool
+  )
+}

--- a/varlink/com.redhat.tuned.defaults
+++ b/varlink/com.redhat.tuned.defaults
@@ -1,0 +1,10 @@
+{
+    "use_recommended_profile": false,
+    "profile": "balanced",
+    "daemon": true,
+    "dynamic_tuning": true,
+    "sleep_interval": 1,
+    "update_interval": 10,
+    "enable_recommend": true,
+    "reapply_sysctl": true
+}


### PR DESCRIPTION
Add com.redhat.tuned. This is heavily based on the existing tuned role, but uses varlink to describe configuration.

I've kept the old role in there for now because it does some additional things, for example it can handle custom profiles.

Depends on:

- [x] #6