### PR TITLE
vagrant: add centos vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ Current testing and development is primarily on RHEL/CentOS/Fedora applying the 
 
 ### Vagrant
 
-You can use [vagrant](http://vagrantup.com) to quickly test the example playbooks on a fedora cloud image. None of the playbooks are run when creating and starting the VM with `vagrant up`. Instead, you can run then manually with
+You can use [vagrant](http://vagrantup.com) to quickly test the example playbooks. The Vagrantfile in this repository defines [multiple machines](https://www.vagrantup.com/docs/multi-machine/) (for now `fedora` and `centos`) and runs all `vagrant` commands on all of them by default. To only run one machine, use
 
 ```shell
-vagrant provision --provision-with NAME
+vagrant up MACHINE
+```
+
+None of the playbooks are run when creating and starting the VM with `vagrant up`. Instead, you can run then manually with
+
+```shell
+vagrant provision [MACHINE] --provision-with NAME
 ```
 
 Where `NAME` is one of `selinux`, `kdump`, `varlink`, etc.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,13 @@
 
 Vagrant.configure(2) do |config|
-    config.vm.box = "fedora/24-cloud-base"
+    config.vm.define "fedora", primary: true do |fedora|
+      fedora.vm.box = "fedora/24-cloud-base"
+      fedora.vm.provision "shell", inline: "dnf install -y python2 python2-dnf libselinux-python"
+    end
 
-    config.vm.provision "shell" do |shell|
-      shell.inline = "dnf install -y python2 python2-dnf libselinux-python"
+    config.vm.define "centos" do |centos|
+      centos.vm.box = "centos/6"
+      centos.vm.provision "shell", inline: "yum install -y python2 libselinux-python"
     end
 
     # Optional provisioners


### PR DESCRIPTION
This makes all vagrant commands apply to all configured machines, so
that playbooks are tested on different OSs simultaneously.

Depends on #9 (tuned legacy didn't work correctly - first bug found with this Vagrantfile ;) )