### PR TITLE
com.redhat.tuned: correctly set common profiles

### DIFF
--- a/roles/com_redhat_tuned/tasks/main.yaml
+++ b/roles/com_redhat_tuned/tasks/main.yaml
@@ -28,9 +28,9 @@
 - set_fact:
     tuned_recommended_profile: "{{ (recommend.stdout == ' *fail') | ternary('',recommend.stdout) }}"
 
-- name: Set Tuned legacy profile {{ tuned_legacy_profiles_map[config.profile] }}
-  command: tuned-adm profile {{ tuned_legacy_profiles_map[config.profile] }}
-  when: tuned_legacy and tuned_legacy_profiles_map.get(config.profile)
+- name: Set Tuned legacy profile {{ tuned_legacy_profiles_map.get(config.profile, config.profile) }}
+  command: tuned-adm profile {{ tuned_legacy_profiles_map.get(config.profile, config.profile) }}
+  when: tuned_legacy and tuned_legacy_profiles_map.get(config.profile, config.profile) != ''
 
 - name: Set Tuned profile {{ config.profile }}
   command: tuned-adm profile {{ config.profile }}


### PR DESCRIPTION
For legacy tuned, fall back to the given profile name if it is not in
the legacy profile map.